### PR TITLE
Scribe 4.x compatibility & @scribeSkip + @scribeDescription annotations

### DIFF
--- a/src/Strategies/BodyParameters/GetFromBodyParamTagFromScribeTdd.php
+++ b/src/Strategies/BodyParameters/GetFromBodyParamTagFromScribeTdd.php
@@ -19,12 +19,13 @@ class GetFromBodyParamTagFromScribeTdd extends GetFromBodyParamTag
 
         [
             'method' => $methodDocBlock,
+            'class' => $classDocBlock
         ]
         = RouteDocBlocker::getDocBlocks($endpointData->route, [
             $testResult['test_class'],
             $testResult['test_method'],
         ]);
-
-        return $this->getBodyParametersFromDocBlock($methodDocBlock->getTags());
+    
+        return $this->getFromTags($methodDocBlock->getTags(), $classDocBlock?->getTags() ?: []);
     }
 }

--- a/src/Strategies/BodyParameters/GetFromBodyParamTagFromScribeTdd.php
+++ b/src/Strategies/BodyParameters/GetFromBodyParamTagFromScribeTdd.php
@@ -9,7 +9,7 @@ use Knuckles\Scribe\Extracting\Strategies\BodyParameters\GetFromBodyParamTag;
 
 class GetFromBodyParamTagFromScribeTdd extends GetFromBodyParamTag
 {
-    public function __invoke(ExtractedEndpointData $endpointData, array $routeRules): ?array
+    public function __invoke(ExtractedEndpointData $endpointData, array $routeRules = []): ?array
     {
         $testResult = RouteTestResult::getTestResultForRoute($endpointData->route);
 

--- a/src/Strategies/BodyParameters/GetFromTestResult.php
+++ b/src/Strategies/BodyParameters/GetFromTestResult.php
@@ -11,7 +11,7 @@ class GetFromTestResult extends Strategy
 {
     use ParamHelpers;
 
-    public function __invoke(ExtractedEndpointData $endpointData, array $routeRules): ?array
+    public function __invoke(ExtractedEndpointData $endpointData, array $routeRules = []): ?array
     {
         $testResult = RouteTestResult::getTestResultForRoute($endpointData->route);
 

--- a/src/Strategies/Headers/GetFromHeaderTagFromScribeTdd.php
+++ b/src/Strategies/Headers/GetFromHeaderTagFromScribeTdd.php
@@ -9,7 +9,7 @@ use Knuckles\Scribe\Extracting\Strategies\Headers\GetFromHeaderTag;
 
 class GetFromHeaderTagFromScribeTdd extends GetFromHeaderTag
 {
-    public function __invoke(ExtractedEndpointData $endpointData, array $routeRules): array
+    public function __invoke(ExtractedEndpointData $endpointData, array $routeRules = []): array
     {
         $testResult = RouteTestResult::getTestResultForRoute($endpointData->route);
 

--- a/src/Strategies/Headers/GetFromHeaderTagFromScribeTdd.php
+++ b/src/Strategies/Headers/GetFromHeaderTagFromScribeTdd.php
@@ -19,12 +19,13 @@ class GetFromHeaderTagFromScribeTdd extends GetFromHeaderTag
 
         [
             'method' => $methodDocBlock,
+            'class' => $classDocBlock
         ]
         = RouteDocBlocker::getDocBlocks($endpointData->route, [
             $testResult['test_class'],
             $testResult['test_method'],
         ]);
-
-        return $this->getHeadersFromDocBlock($methodDocBlock->getTags());
+    
+        return $this->getFromTags($methodDocBlock->getTags(), $classDocBlock?->getTags() ?: []);
     }
 }

--- a/src/Strategies/Metadata/GetFromDocBlocksFromScribeTdd.php
+++ b/src/Strategies/Metadata/GetFromDocBlocksFromScribeTdd.php
@@ -9,7 +9,7 @@ use Knuckles\Scribe\Extracting\Strategies\Metadata\GetFromDocBlocks;
 
 class GetFromDocBlocksFromScribeTdd extends GetFromDocBlocks
 {
-    public function __invoke(ExtractedEndpointData $endpointData, array $routeRules): array
+    public function __invoke(ExtractedEndpointData $endpointData, array $routeRules = []): array
     {
         $testResult = RouteTestResult::getTestResultForRoute($endpointData->route);
 

--- a/src/Strategies/QueryParameters/AddPaginationParametersFromScribeTdd.php
+++ b/src/Strategies/QueryParameters/AddPaginationParametersFromScribeTdd.php
@@ -12,7 +12,7 @@ class AddPaginationParametersFromScribeTdd extends Strategy
 {
     use ParamHelpers;
 
-    public function __invoke(ExtractedEndpointData $endpointData, array $routeRules): ?array
+    public function __invoke(ExtractedEndpointData $endpointData, array $routeRules = []): ?array
     {
         $testResult = RouteTestResult::getTestResultForRoute($endpointData->route);
 

--- a/src/Strategies/QueryParameters/GetFromQueryParamTagFromScribeTdd.php
+++ b/src/Strategies/QueryParameters/GetFromQueryParamTagFromScribeTdd.php
@@ -9,7 +9,7 @@ use Knuckles\Scribe\Extracting\Strategies\QueryParameters\GetFromQueryParamTag;
 
 class GetFromQueryParamTagFromScribeTdd extends GetFromQueryParamTag
 {
-    public function __invoke(ExtractedEndpointData $endpointData, array $routeRules): ?array
+    public function __invoke(ExtractedEndpointData $endpointData, array $routeRules = []): ?array
     {
         $testResult = RouteTestResult::getTestResultForRoute($endpointData->route);
 

--- a/src/Strategies/QueryParameters/GetFromQueryParamTagFromScribeTdd.php
+++ b/src/Strategies/QueryParameters/GetFromQueryParamTagFromScribeTdd.php
@@ -19,12 +19,13 @@ class GetFromQueryParamTagFromScribeTdd extends GetFromQueryParamTag
 
         [
             'method' => $methodDocBlock,
+            'class' => $classDocBlock
         ]
         = RouteDocBlocker::getDocBlocks($endpointData->route, [
             $testResult['test_class'],
             $testResult['test_method'],
         ]);
-
-        return $this->getQueryParametersFromDocBlock($methodDocBlock->getTags());
+    
+        return $this->getFromTags($methodDocBlock->getTags(), $classDocBlock?->getTags() ?: []);
     }
 }

--- a/src/Strategies/QueryParameters/GetFromTestResult.php
+++ b/src/Strategies/QueryParameters/GetFromTestResult.php
@@ -11,7 +11,7 @@ class GetFromTestResult extends Strategy
 {
     use ParamHelpers;
 
-    public function __invoke(ExtractedEndpointData $endpointData, array $routeRules): ?array
+    public function __invoke(ExtractedEndpointData $endpointData, array $routeRules = []): ?array
     {
         $testResult = RouteTestResult::getTestResultForRoute($endpointData->route);
 

--- a/src/Strategies/ResponseFields/GetFromResponseFieldTagFromScribeTdd.php
+++ b/src/Strategies/ResponseFields/GetFromResponseFieldTagFromScribeTdd.php
@@ -19,12 +19,13 @@ class GetFromResponseFieldTagFromScribeTdd extends GetFromResponseFieldTag
 
         [
             'method' => $methodDocBlock,
+            'class' => $classDocBlock
         ]
         = RouteDocBlocker::getDocBlocks($endpointData->route, [
             $testResult['test_class'],
             $testResult['test_method'],
         ]);
-
-        return $this->getResponseFieldsFromDocBlock($methodDocBlock->getTags(), $endpointData->responses);
+    
+        return $this->getFromTags($methodDocBlock->getTags(), $classDocBlock?->getTags() ?: []);
     }
 }

--- a/src/Strategies/ResponseFields/GetFromResponseFieldTagFromScribeTdd.php
+++ b/src/Strategies/ResponseFields/GetFromResponseFieldTagFromScribeTdd.php
@@ -9,7 +9,7 @@ use Knuckles\Scribe\Extracting\Strategies\ResponseFields\GetFromResponseFieldTag
 
 class GetFromResponseFieldTagFromScribeTdd extends GetFromResponseFieldTag
 {
-    public function __invoke(ExtractedEndpointData $endpointData, array $routeRules): ?array
+    public function __invoke(ExtractedEndpointData $endpointData, array $routeRules = []): ?array
     {
         $testResult = RouteTestResult::getTestResultForRoute($endpointData->route);
 

--- a/src/Strategies/Responses/GetFromTestResult.php
+++ b/src/Strategies/Responses/GetFromTestResult.php
@@ -11,7 +11,7 @@ class GetFromTestResult extends Strategy
 {
     use ParamHelpers;
 
-    public function __invoke(ExtractedEndpointData $endpointData, array $routeRules): ?array
+    public function __invoke(ExtractedEndpointData $endpointData, array $routeRules = []): ?array
     {
         $testResult = RouteTestResult::getTestResultForRoute($endpointData->route);
 

--- a/src/Strategies/Responses/UseResponseFileTagFromScribeTdd.php
+++ b/src/Strategies/Responses/UseResponseFileTagFromScribeTdd.php
@@ -9,7 +9,7 @@ use Knuckles\Scribe\Extracting\Strategies\Responses\UseResponseFileTag;
 
 class UseResponseFileTagFromScribeTdd extends UseResponseFileTag
 {
-    public function __invoke(ExtractedEndpointData $endpointData, array $routeRules): ?array
+    public function __invoke(ExtractedEndpointData $endpointData, array $routeRules = []): ?array
     {
         $testResult = RouteTestResult::getTestResultForRoute($endpointData->route);
 

--- a/src/Strategies/Responses/UseResponseTagFromScribeTdd.php
+++ b/src/Strategies/Responses/UseResponseTagFromScribeTdd.php
@@ -9,7 +9,7 @@ use Knuckles\Scribe\Extracting\Strategies\Responses\UseResponseTag;
 
 class UseResponseTagFromScribeTdd extends UseResponseTag
 {
-    public function __invoke(ExtractedEndpointData $endpointData, array $routeRules): ?array
+    public function __invoke(ExtractedEndpointData $endpointData, array $routeRules = []): ?array
     {
         $testResult = RouteTestResult::getTestResultForRoute($endpointData->route);
 

--- a/src/Strategies/UrlParameters/GetFromTestResult.php
+++ b/src/Strategies/UrlParameters/GetFromTestResult.php
@@ -11,7 +11,7 @@ class GetFromTestResult extends Strategy
 {
     use ParamHelpers;
 
-    public function __invoke(ExtractedEndpointData $endpointData, array $routeRules): ?array
+    public function __invoke(ExtractedEndpointData $endpointData, array $routeRules = []): ?array
     {
         $testResult = RouteTestResult::getTestResultForRoute($endpointData->route);
 

--- a/src/Strategies/UrlParameters/GetFromUrlParamTagFromScribeTdd.php
+++ b/src/Strategies/UrlParameters/GetFromUrlParamTagFromScribeTdd.php
@@ -19,12 +19,13 @@ class GetFromUrlParamTagFromScribeTdd extends GetFromUrlParamTag
 
         [
             'method' => $methodDocBlock,
+            'class' => $classDocBlock
         ]
         = RouteDocBlocker::getDocBlocks($endpointData->route, [
             $testResult['test_class'],
             $testResult['test_method'],
         ]);
-
-        return $this->getUrlParametersFromDocBlock($methodDocBlock->getTags());
+    
+        return $this->getFromTags($methodDocBlock->getTags(), $classDocBlock?->getTags() ?: []);
     }
 }

--- a/src/Strategies/UrlParameters/GetFromUrlParamTagFromScribeTdd.php
+++ b/src/Strategies/UrlParameters/GetFromUrlParamTagFromScribeTdd.php
@@ -9,7 +9,7 @@ use Knuckles\Scribe\Extracting\Strategies\UrlParameters\GetFromUrlParamTag;
 
 class GetFromUrlParamTagFromScribeTdd extends GetFromUrlParamTag
 {
-    public function __invoke(ExtractedEndpointData $endpointData, array $routeRules): ?array
+    public function __invoke(ExtractedEndpointData $endpointData, array $routeRules = []): ?array
     {
         $testResult = RouteTestResult::getTestResultForRoute($endpointData->route);
 

--- a/src/Tests/ExampleCreator.php
+++ b/src/Tests/ExampleCreator.php
@@ -7,7 +7,6 @@ use AjCastro\ScribeTdd\Tests\Traits\SetProps;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Routing\Route;
-use Illuminate\Support\Str;
 
 class ExampleCreator implements Arrayable, Jsonable
 {

--- a/src/Tests/ExampleCreator.php
+++ b/src/Tests/ExampleCreator.php
@@ -17,6 +17,7 @@ class ExampleCreator implements Arrayable, Jsonable
     public $testMethod;
     public $dataName;
     public $providedData;
+    public $description;
     public Route $route;
 
     private $exampleRequests;
@@ -129,6 +130,7 @@ class ExampleCreator implements Arrayable, Jsonable
             'test_method'   => $this->testMethod,
             'data_name'     => $this->dataName,
             'provided_data' => $this->providedData,
+            'description'   => $this->description,
             'key'           => $this->instanceKey(),
             'route' => [
                 'uri'     => $this->route->uri,

--- a/src/Tests/ExampleRequest.php
+++ b/src/Tests/ExampleRequest.php
@@ -61,17 +61,8 @@ class ExampleRequest
         return [
             'status' => $statusCode = $this->response->getStatusCode(),
             'headers' => $this->response->headers->all(),
-            'description' => $statusCode.', '.static::guessResponseDescription($this->exampleCreator->testMethod),
+            'description' => $statusCode.', '.$this->exampleCreator->description,
             'content' => (string) $this->response->getContent(),
         ];
-    }
-
-    private static function guessResponseDescription($testMethod)
-    {
-        if (Str::startsWith($testMethod, 'test')) {
-            $testMethod = substr($testMethod, 4);
-        }
-
-        return trim(str_replace('_', ' ', Str::snake($testMethod)));
     }
 }

--- a/src/Tests/HttpExamples/HttpExampleCreatorMiddleware.php
+++ b/src/Tests/HttpExamples/HttpExampleCreatorMiddleware.php
@@ -3,8 +3,6 @@
 namespace AjCastro\ScribeTdd\Tests\HttpExamples;
 
 use Closure;
-use Illuminate\Http\Request;
-use Illuminate\Testing\TestResponse;
 use AjCastro\ScribeTdd\Tests\ExampleCreator;
 use AjCastro\ScribeTdd\Tests\ExampleRequest;
 


### PR DESCRIPTION
@ajcastro This fixes the issues with Scribe 4.x

I've also added `@scribeSkip` and `@scribeDescription` annotations for tests to exclude tests from being used as examples and to customize the description for each example rather than using the test method name.